### PR TITLE
更新日志配置

### DIFF
--- a/MangoBlog/nlog.config
+++ b/MangoBlog/nlog.config
@@ -3,7 +3,7 @@
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       autoReload="true"
       internalLogLevel="Info"
-      internalLogFile="log\internal-nlog.txt">
+      internalLogFile="log/internal-nlog.txt">
 
   <!-- enable asp.net core layout renderers -->
   <extensions>
@@ -13,11 +13,11 @@
   <!-- the targets to write to -->
   <targets>
     <!-- write logs to file  -->
-    <target xsi:type="File" name="allfile" fileName="log\nlog-all-${shortdate}.log"
+    <target xsi:type="File" name="allfile" fileName="log/nlog-all-${shortdate}.log"
             layout="${longdate}|${event-properties:item=EventId_Id}|${uppercase:${level}}|${logger}|${message} ${exception:format=tostring}" />
 
     <!-- another file log, only own logs. Uses some ASP.NET core renderers -->
-    <target xsi:type="File" name="ownFile-web" fileName="log\nlog-own-${shortdate}.log"
+    <target xsi:type="File" name="ownFile-web" fileName="log/nlog-own-${shortdate}.log"
             layout="${longdate}|${event-properties:item=EventId_Id}|${uppercase:${level}}|${logger}|${message} ${exception:format=tostring}|url: ${aspnet-request-url}|action: ${aspnet-mvc-action}" />
   </targets>
 


### PR DESCRIPTION
- 修复`nlog.config`配置文件盘符斜杠错误导致在生成环境日志文件直接生成在了项目根目录